### PR TITLE
Rename method, adapt tests

### DIFF
--- a/samples/eps_refund.php
+++ b/samples/eps_refund.php
@@ -1,35 +1,35 @@
 <?php
 /*
-This file handles the confirmation call from the Scheme Operator (after a payment was received). It is called twice:
-1. for Vitality-Check, according to "Abbildung 6-11: epsp:VitalityCheckDetails" (eps Pflichtenheft 2.5)
-2. for the actual payment confirmation (Zahlungsbestätigung)
+This file handles the refund process of a previous EPS payment
 */
 
 require_once('../vendor/autoload.php');
 
 use at\externet\eps_bank_transfer;
 
-$userID = 'AKLJS231534';            // Eps "Händler-ID"/UserID = epsp:UserId
-$pin = 'topSecret';              // Secret for authentication / PIN = part of epsp:MD5Fingerprint
+$userID = 'AKLJS231534';            // Eps "Händler-ID"/UserID = epsr:UserId
+$pin = 'topSecret';                 // Secret for authentication / PIN = part of epsr:SHA256Fingerprint
 $merchantIban = 'AT611904300234573201';
 
 $refundRequest = new eps_bank_transfer\EpsRefundRequest(
-    date('Y-m-d\TH:i:s'),
-    'epsM7DPP3R12',
+    date('Y-m-d\TH:i:s'),   // Current date-time. Must not diverge more than 3hrs from SO time
+    'epsM7DPP3R12',         // EPS Transaction ID from epsp:BankResponse
     $merchantIban,
-    "12.00",
-    'EUR',
+    "12.00",                // Amount to refund. Must be lower or equal the original transaction amount
+    'EUR',                  // Currency for the amount. EPS Refund 1.0.1 only accepts EUR
     $userID,
     $pin,
-    'Refund Reason' // RefundReference (optional)
+    'Refund Reason'         // RefundReference (optional) = Auftraggeberreferenz
 );
 
 $testMode = "yes";
 $soCommunicator = new eps_bank_transfer\SoCommunicator($testMode == "yes");
-$refundResponse = $soCommunicator->ProcessRefund($refundRequest);
+$refundResponse = $soCommunicator->SendRefundRequest($refundRequest);
 
 $xml = new \SimpleXMLElement($refundResponse);
 $soAnswer = $xml->children(eps_bank_transfer\XMLNS_epsr);
 
 echo $soAnswer->StatusCode . ', ' . $soAnswer->ErrorMsg;
+// Return code 000 (No Errors) only means the refund request was accepted by the bank.
+// A manual approval might be required.
 ?>

--- a/src/EpsRefundRequest.php
+++ b/src/EpsRefundRequest.php
@@ -51,8 +51,6 @@ class EpsRefundRequest
      *
      * @return SimpleXMLElement The XML element representing the refund request.
      */
-
-
     public function __construct(
         string  $CreDtTm,
         string  $TransactionId,

--- a/src/SoCommunicator.php
+++ b/src/SoCommunicator.php
@@ -327,7 +327,7 @@ class SoCommunicator
 
 
     /**
-     * Executes a refund request using the EpsRefundRequest object.
+     * Sends a refund request using the EpsRefundRequest object.
      *
      * @param EpsRefundRequest $refundRequest The refund request data to be sent.
      * @param string|null $targetUrl Optional endpoint URL for EPS refund requests. Defaults to the base URL with refund path.
@@ -335,10 +335,8 @@ class SoCommunicator
      * @return string The response body from the refund request.
      * @throws HttpResponseException If the request fails with a non-200 HTTP status code.
      */
-    public function ProcessRefund(EpsRefundRequest $refundRequest, $targetUrl = null, $logMessage = null)
+    public function SendRefundRequest(EpsRefundRequest $refundRequest, $targetUrl = null, $logMessage = null)
     {
-        $this->WriteLog($logMessage ?? 'Initiating refund request.');
-
         if ($targetUrl === null)
             $targetUrl = $this->BaseUrl . '/refund/eps/v2_6';
 
@@ -347,8 +345,6 @@ class SoCommunicator
 
         $response = $this->PostUrl($targetUrl, $xmlData, $logMessage ?? 'Sending refund request to ' . $targetUrl);
         XmlValidator::ValidateEpsRefund($response);
-
-        $this->WriteLog('Refund request completed successfully.');
 
         return $response;
     }

--- a/tests/unit/at/externet/eps_bank_transfer/EpsData/RefundResponseFingerprintFailed004.xml
+++ b/tests/unit/at/externet/eps_bank_transfer/EpsData/RefundResponseFingerprintFailed004.xml
@@ -1,7 +1,0 @@
-<epsr:EpsRefundResponse xsi:schemaLocation="http://www.stuzza.at/namespaces/eps/refund/2018/09 EPSRefund-V26.xsd"
-                        xmlns:dsig="http://www.w3.org/2000/09/xmldsig#"
-                        xmlns:epsr="http://www.stuzza.at/namespaces/eps/refund/2018/09"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <epsr:StatusCode>004</epsr:StatusCode>
-    <epsr:ErrorMsg>Autorisierungsdaten fehlerhaft - SHA256 fingerprint check failed</epsr:ErrorMsg>
-</epsr:EpsRefundResponse>

--- a/tests/unit/at/externet/eps_bank_transfer/EpsData/RefundResponseInvalidIban010.xml
+++ b/tests/unit/at/externet/eps_bank_transfer/EpsData/RefundResponseInvalidIban010.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<epsr:EpsRefundResponse xsi:schemaLocation="http://www.stuzza.at/namespaces/eps/refund/2018/09 EPSRefund-V26.xsd"
-                        xmlns:dsig="http://www.w3.org/2000/09/xmldsig#"
-                        xmlns:epsr="http://www.stuzza.at/namespaces/eps/refund/2018/09"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <epsr:StatusCode>010</epsr:StatusCode>
-    <epsr:ErrorMsg>IBAN ungueltig - customer data not available</epsr:ErrorMsg>
-</epsr:EpsRefundResponse>

--- a/tests/unit/at/externet/eps_bank_transfer/XmlValidatorTest.php
+++ b/tests/unit/at/externet/eps_bank_transfer/XmlValidatorTest.php
@@ -36,10 +36,16 @@ class XmlValidatorTest extends BaseTest
         $ret = XmlValidator::ValidateBankList($this->GetEpsData('BankListSample.xml'));
         $this->assertTrue($ret);
     }
-    
+
     public function testWithSignatureReturnsTrue()
     {
         $ret = XmlValidator::ValidateEpsProtocol($this->GetEpsData('BankConfirmationDetailsWithSignature.xml'));
+        $this->assertTrue($ret);
+    }
+
+    public function testRefundResponseValid()
+    {
+        $ret = XmlValidator::ValidateEpsRefund($this->GetEpsData('RefundResponseAccepted000.xml'));
         $this->assertTrue($ret);
     }
 }


### PR DESCRIPTION
* Rename ProcessRefund to SendRefundRequest
* Remove redundant WriteLog calls
* Add test for XMLValidation of RefundResponse
* Adapt test to actually test the request not the response in SoCommunicatorTest.php

The name `SendRefundRequest` seems to make more sense to me, as it actually only sends the RefundRequest and is noct actually processed.

The three tests only tested that the method returned the string that was set up in the test. I replaced them with similar tests as for `SendTransferInitiatorDetails`